### PR TITLE
fix(demo/app.py): Drop nested button.

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -122,6 +122,10 @@ if uploaded_file is not None:
                 )
 
                 with st.spinner("Generating Audio..."):
-                    waveform = parse_script_to_waveform(final_script, demo_podcast_config)
-                save_waveform_as_file(waveform, demo_podcast_config.sampling_rate, filename)
+                    waveform = parse_script_to_waveform(
+                        final_script, demo_podcast_config
+                    )
+                save_waveform_as_file(
+                    waveform, demo_podcast_config.sampling_rate, filename
+                )
                 st.audio(filename)


### PR DESCRIPTION
Background in https://discuss.streamlit.io/t/how-to-do-nested-button-and-print-both-button-outputs/33741

@Kostis-S-Z it turns out that having 2 nested buttons requires some more elaborated changes to handle the session state. This is a quick fix that just makes the demo work.

There is a different problem, though, which is that `parse_script_to_waveform` doesn't work with the current output format. In the current test, you are setting the input differently and that is why the test pass. You are missing some quotes around the strings like:

```
"Speaker 1": "Yes, and by working together, we can create a more accessible and inclusive AI ecosystem that benefits everyone."
```
