### PR TITLE
enh(docs.yaml): Check for doc failures on pull_request.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: pip install -e '.[docs]'
 
       - name: Build docs
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         run: mkdocs build -s
 
       - name: Publish docs


### PR DESCRIPTION
## What's changing

Update the Documentation workflow to build the docs on pull_request.
This allow us to catch failures like the broken links in #36 before we merge and deploy the docs.
