### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  release:
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade pip
+          pip --version
+
+      - name: Install
+        run: python -m pip install build setuptools
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload package
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What's changing

Add a new workflow to publish the blueprint to pypi.

I have configured a trusted published on pypi following https://docs.pypi.org/trusted-publishers/ . 
Project will be created on the first release