### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - directory: "/"
+    package-ecosystem: "pip"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "maintenance"
+
+  - directory: "/"
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "maintenance"


### PR DESCRIPTION
## What's changing

Enable dependabot updates for the repo. This is an easy way to keep both the python and github workflow dependencies updated .

## How to test it

Once the PR is merged we will start getting weekly PRs

## Additional notes for reviewers

See https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#about-dependabot