### PR TITLE
Save single audio file & script when completed in demo app

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -133,7 +133,14 @@ if uploaded_file is not None:
                     complete_script += text
                     text = ""
 
-            complete_audio = np.concatenate(complete_audio)
-            save_waveform_as_file(waveform=complete_audio, sampling_rate=speech_model.config.sampling_rate, filename="podcast.wav")
+            with st.spinner("Saving Podcast to file..."):
+                complete_audio = np.concatenate(complete_audio)
+                save_waveform_as_file(
+                    waveform=complete_audio,
+                    sampling_rate=speech_model.config.sampling_rate,
+                    filename="podcast.wav",
+                )
             with open("script.txt", "w") as f:
                 f.write(complete_script)
+
+            st.subheader("Podcast and Script saved to disk!")


### PR DESCRIPTION
# What's changing

In the demo app, when the script and audio generation of the whole podcast is complete, we want to save the complete audio as a single audio file and the complete script as a text file. This PR is an implementation of two buttons that enable this feature.

Closes #33 

# How to test it

Steps to test the changes:

1. Install package `pip install -e .`
2. Run demo app `python -m streamlit run demo/app.py`
3. Generate a podcast and wait for it to finish
4. Click "Save Podcast to audio file" and verify that a `podcast.wav` file is generated under the root directory
5. Click "Save Podcast script to text file" and verify that a `script.txt` file is generated under the root directory

# Additional notes for reviewers

Currently the generated podcast text disappears when you click one of the two buttons.

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and under `/docs`)
