### PR TITLE
Add gpu support

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 import streamlit as st
+import torch
 
 from document_to_podcast.preprocessing import DATA_LOADERS, DATA_CLEANERS
 from document_to_podcast.inference.model_loaders import (
@@ -35,6 +36,8 @@ SPEAKER_DESCRIPTIONS = {
     "2": "Jon's voice is calm with very clear audio and no background noise.",
 }
 
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
 
 @st.cache_resource
 def load_text_to_text_model():
@@ -45,7 +48,7 @@ def load_text_to_text_model():
 
 @st.cache_resource
 def load_text_to_speech_model_and_tokenizer():
-    return load_parler_tts_model_and_tokenizer("parler-tts/parler-tts-mini-v1", "cpu")
+    return load_parler_tts_model_and_tokenizer("parler-tts/parler-tts-mini-v1", device)
 
 
 st.title("Document To Podcast")
@@ -117,6 +120,7 @@ if uploaded_file is not None:
                             speech_model,
                             speech_tokenizer,
                             SPEAKER_DESCRIPTIONS[speaker_id],
+                            device=device,
                         )
                     st.audio(speech, sample_rate=speech_model.config.sampling_rate)
                     text = ""

--- a/demo/app.py
+++ b/demo/app.py
@@ -42,7 +42,8 @@ device = "cuda:0" if torch.cuda.is_available() else "cpu"
 @st.cache_resource
 def load_text_to_text_model():
     return load_llama_cpp_model(
-        model_id="allenai/OLMoE-1B-7B-0924-Instruct-GGUF/olmoe-1b-7b-0924-instruct-q8_0.gguf"
+        model_id="allenai/OLMoE-1B-7B-0924-Instruct-GGUF/olmoe-1b-7b-0924-instruct-q8_0.gguf",
+        device=device,
     )
 
 

--- a/src/document_to_podcast/inference/model_loaders.py
+++ b/src/document_to_podcast/inference/model_loaders.py
@@ -5,19 +5,18 @@ from parler_tts import ParlerTTSForConditionalGeneration
 from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 
 
-def load_llama_cpp_model(
-    model_id: str,
-) -> Llama:
+def load_llama_cpp_model(model_id: str, device: str = "cpu") -> Llama:
     """
     Loads the given model_id using Llama.from_pretrained.
 
     Examples:
         >>> model = load_llama_cpp_model(
-            "allenai/OLMoE-1B-7B-0924-Instruct-GGUF/olmoe-1b-7b-0924-instruct-q8_0.gguf")
+            "allenai/OLMoE-1B-7B-0924-Instruct-GGUF/olmoe-1b-7b-0924-instruct-q8_0.gguf", "cpu")
 
     Args:
         model_id (str): The model id to load.
             Format is expected to be `{org}/{repo}/{filename}`.
+        device (str): The device to load the model on, such as "cuda:0" or "cpu".
 
     Returns:
         Llama: The loaded model.
@@ -26,8 +25,11 @@ def load_llama_cpp_model(
     model = Llama.from_pretrained(
         repo_id=f"{org}/{repo}",
         filename=filename,
+        # -1 means offload all layers to GPU, but you can also define to have some in CPU, some in GPU
+        n_gpu_layers=0 if device == "cpu" else -1,
         # 0 means that the model limit will be used, instead of the default (512) or other hardcoded value
         n_ctx=0,
+        verbose=True,
     )
     return model
 

--- a/src/document_to_podcast/inference/text_to_speech.py
+++ b/src/document_to_podcast/inference/text_to_speech.py
@@ -7,9 +7,10 @@ def _speech_generation_parler(
     model: PreTrainedModel,
     tokenizer: PreTrainedTokenizerBase,
     speaker_description: str,
+    device: str,
 ) -> np.ndarray:
-    input_ids = tokenizer(speaker_description, return_tensors="pt").input_ids
-    prompt_input_ids = tokenizer(input_text, return_tensors="pt").input_ids
+    input_ids = tokenizer(speaker_description, return_tensors="pt").input_ids.to(device)
+    prompt_input_ids = tokenizer(input_text, return_tensors="pt").input_ids.to(device)
 
     generation = model.generate(input_ids=input_ids, prompt_input_ids=prompt_input_ids)
     waveform = generation.cpu().numpy().squeeze()
@@ -22,6 +23,7 @@ def text_to_speech(
     model: PreTrainedModel,
     tokenizer: PreTrainedTokenizerBase,
     speaker_profile: str,
+    device: str = "cpu",
 ) -> np.ndarray:
     """
     Generates a speech waveform using the input_text, a model and a speaker profile to define a distinct voice pattern.
@@ -34,11 +36,14 @@ def text_to_speech(
         model (PreTrainedModel): The model used for generating the waveform.
         tokenizer (PreTrainedTokenizerBase): The tokenizer used for tokenizing the text in order to send to the model.
         speaker_profile (str): A description used by the ParlerTTS model to configure the speaker profile.
+        device (str): The device to compute the generation on, such as "cuda:0" or "cpu".
     Returns:
         numpy array: The waveform of the speech as a 2D numpy array
     """
     model_id = model.config.name_or_path
     if "parler" in model_id:
-        return _speech_generation_parler(input_text, model, tokenizer, speaker_profile)
+        return _speech_generation_parler(
+            input_text, model, tokenizer, speaker_profile, device
+        )
     else:
         raise NotImplementedError(f"Model {model_id} not yet implemented for TTS")


### PR DESCRIPTION
# What's changing

Add support for both the `text-to-text` and the `text-to-speech` model to be loaded on the GPU.

# How to test it

Steps to test the changes:

1. Run the demo
2. Check with `nvidia-smi` that your GPU has loaded the models

# Additional notes for reviewers

This became more difficult than I expected because the two different frameworks of the models need to have support for the same cuda toolkit. Support for the `text-to-speech` is complete and was easy. Support for the `text-to-text` has proven quite difficult.

Some rough benchmarks:
Setup: Count time from the moment you upload the document until the first audio sample of speaker 1 is generated (includes loading both models and running inference once with both models). The `.html` file in `example_data` was used. GPU: RTX 2060

CPU: `text-to-text` & `text-to-speech` -> 2min, 41sec
CPU: `text-to-text`  GPU: `text-to-speech` -> 1min, 27 sec (!)

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and under `/docs`)
