### PR TITLE
Fix duplicate text area bug 

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -71,12 +71,18 @@ if uploaded_file is not None:
     raw_text = DATA_LOADERS[extension](uploaded_file)
     with col1:
         st.subheader("Raw Text")
-        st.text_area(f"Total Length: {len(raw_text)}", f"{raw_text[:500]} . . .")
+        st.text_area(
+            f"Number of characters before cleaning: {len(raw_text)}",
+            f"{raw_text[:500]} . . .",
+        )
 
     clean_text = DATA_CLEANERS[extension](raw_text)
     with col2:
         st.subheader("Cleaned Text")
-        st.text_area(f"Total Length: {len(clean_text)}", f"{clean_text[:500]} . . .")
+        st.text_area(
+            f"Number of characters after cleaning: {len(clean_text)}",
+            f"{clean_text[:500]} . . .",
+        )
 
     st.divider()
     st.header("Downloading and Loading models")


### PR DESCRIPTION
# What's changing

Make text areas distinct to prevent streamlit from crashing when the content is identical. 
The low-hanging fruit solution was to simply change the "pre-text" of the areas to be different so from:
`Total Length:` for both to `Number of characters before cleaning:` and `Number of characters after cleaning:`

For more info check #43 .

Closes #43 

# How to test it

Steps to test the changes:

1. Run demo app
2. Create empty file file.md and inside write This is an example
3. Upload file to app
4. No crash :tada: 

# Additional notes for reviewers

~

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and under `/docs`)
