### PR TITLE
Only run tests on `src` and `tests` changes.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,13 @@ name: Tests
 on:
   push:
     branches: [main]
+    paths: 
+      - 'src/**'
+      - 'tests/**'
   pull_request:
+    paths: 
+      - 'src/**'
+      - 'tests/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Prevent to run `tests` workflow, which takes some time, unnecessarily (i.e when updating docs)
