### PR TITLE
enh(docs): Show GitHub repo.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: Blueprints Docs
+repo_url: https://github.com/mozilla-ai/document-to-podcast
+repo_name: document-to-podcast
 
 nav:
   - Home: index.md
@@ -9,6 +11,8 @@ nav:
   - Future Features & Contributions: future-features-contributions.md
 
 theme:
+  icon:
+    repo: fontawesome/brands/github
   name: material
   palette:
     - scheme: default


### PR DESCRIPTION
Minor change to show the GitHub repository info at the top right:

![image](https://github.com/user-attachments/assets/4330c1e3-f2b6-46c9-ae3e-9b87986f81fd)


