### PR TITLE
fix(devcontainer): pin Python version.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
       "ghcr.io/devcontainers/features/python": {
-        "version": "latest"
+        "version": "3.10"
       }
     },
     "postCreateCommand": "bash .github/setup.sh"


### PR DESCRIPTION
Using latest was installing Python 3.13 which caused the installation to fail (it appears there are no torchaudio wheels available for 3.13)
