### PR TITLE
Add .gitattributes to ignore files under example_data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+example_data/* linguist-vendored


### PR DESCRIPTION
# What's changing

Currently GitHub thinks that our repo consists of 73.5% HTML code because of a file under `example_data`. By using a `.gitattributes` we can override github-linguist auto-detection to ignore files under that directory. More info [here](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md) 

# How to test it

Apparently it might take a few hours (or days) until the change takes effect.

# Additional notes for reviewers

~

# I already...

- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and under `/docs`)
