### PR TITLE
Remove unused config.device reference in cli.py logging

### DIFF
--- a/src/document_to_podcast/cli.py
+++ b/src/document_to_podcast/cli.py
@@ -105,7 +105,7 @@ def document_to_podcast(
     logger.info(f"Loading {config.text_to_text_model}")
     text_model = load_llama_cpp_model(model_id=config.text_to_text_model)
 
-    logger.info(f"Loading {config.text_to_speech_model} on {config.device}")
+    logger.info(f"Loading {config.text_to_speech_model}
     if "oute" in config.text_to_speech_model.lower():
         speech_model = load_outetts_model(model_id=config.text_to_speech_model)
         speech_tokenizer = None

--- a/src/document_to_podcast/cli.py
+++ b/src/document_to_podcast/cli.py
@@ -105,7 +105,7 @@ def document_to_podcast(
     logger.info(f"Loading {config.text_to_text_model}")
     text_model = load_llama_cpp_model(model_id=config.text_to_text_model)
 
-    logger.info(f"Loading {config.text_to_speech_model}
+    logger.info(f"Loading {config.text_to_speech_model}")
     if "oute" in config.text_to_speech_model.lower():
         speech_model = load_outetts_model(model_id=config.text_to_speech_model)
         speech_tokenizer = None


### PR DESCRIPTION
## Description
Fixed an AttributeError that occurs when running document-to-podcast due to a reference to an undefined `config.device` attribute in the logging statement.

## Changes
- Modified logging statement in cli.py to remove unused device reference
- Changed:
  ```python
  logger.info(f"Loading {config.text_to_speech_model} on {config.device}")