### PR TITLE
Use GitHub Actions cache in Docker build

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -37,3 +37,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -29,8 +29,8 @@ jobs:
           flavor: |
             latest=auto
 
-      - name: Set BuildKit
-        run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -29,6 +29,9 @@ jobs:
           flavor: |
             latest=auto
 
+      - name: Set BuildKit
+        run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: blueprints-runner
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/demo/download_models.py
+++ b/demo/download_models.py
@@ -7,9 +7,8 @@ from document_to_podcast.inference.model_loaders import (
     load_outetts_model,
 )
 
-"""
+
 load_llama_cpp_model(
     "allenai/OLMoE-1B-7B-0924-Instruct-GGUF/olmoe-1b-7b-0924-instruct-q8_0.gguf"
 )
-"""
 load_outetts_model("OuteAI/OuteTTS-0.2-500M-GGUF/OuteTTS-0.2-500M-FP16.gguf")

--- a/demo/download_models.py
+++ b/demo/download_models.py
@@ -7,7 +7,9 @@ from document_to_podcast.inference.model_loaders import (
     load_outetts_model,
 )
 
+"""
 load_llama_cpp_model(
     "allenai/OLMoE-1B-7B-0924-Instruct-GGUF/olmoe-1b-7b-0924-instruct-q8_0.gguf"
 )
+"""
 load_outetts_model("OuteAI/OuteTTS-0.2-500M-GGUF/OuteTTS-0.2-500M-FP16.gguf")


### PR DESCRIPTION
This should speed up builds (currently takes 11 min without cache).

https://docs.docker.com/build/cache/backends/gha/#synopsis

