### PR TITLE
Add fire to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10,<3.13"
 dynamic = ["version"]
 dependencies = [
   "beautifulsoup4",
+  "fire",
   "huggingface-hub",
   "llama-cpp-python",
   "loguru",


### PR DESCRIPTION
# What's changing

Currently, if you try to run the CLI app you will get `ModuleNotFoundError: No module named 'fire'`. This PR fixes this by adding `fire` to the core project dependencies.

# How to test it

Steps to test the changes:

1. `pip install -e .`
2. `document-to-podcast --from_config example_data/config.yaml`
3. No crash :tada: 

# Additional notes for reviewers

~

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [N/A] Added some tests for any new functionality
- [N/A] Updated the documentation (both comments in code and under `/docs`)
