### PR TITLE
Enable user to exit podcast generation gracefully

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,8 @@ document-to-podcast \
 --text_to_text_model "Qwen/Qwen2.5-1.5B-Instruct-GGUF/qwen2.5-1.5b-instruct-q8_0.gguf"
 ```
 
+Note that you can also exit the podcast generation prematurely (before the whole podcast is created), by pressing Ctrl+C in the terminal. This will make the application stop the generation, but still save the result (script & audio) to disk up until that point.
+
 ---
 
 ::: document_to_podcast.cli.document_to_podcast


### PR DESCRIPTION
# What's changing

While developing #72 , I implemented this tiny feature because it made testing easier.
Basically, wrap the podcast generation loop in a `try/except` so that the user can `Ctrl+C` in the terminal and exit, while saving the generated podcast up that point. I thought maybe its useful to have in general.


# How to test it

Steps to test the changes:

1. `pip install -e .`
2. ` document-to-podcast --from_config example_data/config.yaml`
3. Wait for some text & audio to be generated
4. Press Ctrl+C to stop the podcast generation before it finishes
5. Verify that `podcast.txt` and `podcast.wav` was created with the podcast generated up to that point

# Additional notes for reviewers

[N/A]

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and under `/docs`)
