### PR TITLE
Simplify README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ We welcome all kinds of contributions, from improving customization, to extendin
 
 ### **Submit Pull Requests** 💻
 - Fork the repository and create a new branch for your changes.
+- Install [pre-commit](https://pre-commit.com/) to ensure the code is formatted and standardized correctly, by running `pip install pre-commit` and then `pre-commit install`.
 - Ensure your branch is up-to-date with the main branch before submitting the PR
 - Please follow the PR template, adding as much detail as possible, including how to test the changes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Get started right away using one of the options below:
 
 You can also install and use the blueprint locally:
 
-<table>
+<table style="width:100%">
 <tr>
 <th>CLI</th>
 <th>Demo App</th>

--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ Get started right away using one of the options below:
 
 You can also install and use the blueprint locally:
 
-<table style="width:100%">
-<tr>
-<th>CLI</th>
-<th>Demo App</th>
-</tr>
-<tr>
-<td>
+### CLI
 
 ```bash
 pip install document-to-podcast
@@ -44,8 +38,7 @@ document-to-podcast \
 --text_to_text_model "Qwen/Qwen2.5-1.5B-Instruct-GGUF/qwen2.5-1.5b-instruct-q8_0.gguf"
 ```
 
-</td>
-<td>
+### Demo App
 
 ```bash
 git clone https://github.com/mozilla-ai/document-to-podcast.git
@@ -56,9 +49,7 @@ pip install -e .
 ```bash
 python -m streamlit run demo/app.py
 ```
-</td>
-</tr>
-</table>
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@
 [![Ruff](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/lint.yaml/badge.svg?label=Ruff)](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/lint.yaml/)
 
 This blueprint demonstrate how you can use open-source models & tools to convert input documents into a podcast featuring two speakers.
-It is designed to work on most local setups or with [GitHub Codespaces](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb), meaning no external API calls or GPU access is required. This makes it more accessible and privacy-friendly by keeping everything local.
+It is designed to work on most local setups, meaning no external API calls or GPU access is required.
+This makes it more accessible and privacy-friendly by keeping everything local.
 
 <img src="./images/document-to-podcast-diagram.png" width="1200" alt="document-to-podcast Diagram" />
 
-### 👉 📖 For more detailed guidance on using this project, please visit our [Docs here](https://mozilla-ai.github.io/document-to-podcast/).
+### 👉 📖 For more detailed guidance on using this project, please visit our [Docs](https://mozilla-ai.github.io/document-to-podcast/).
 
+### 👉 🧠 Check the [Supported Models](https://mozilla-ai.github.io/document-to-podcast/customization/#supported-models).
 
 ## Quick-start
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ It is designed to work on most local setups or with [GitHub Codespaces](https://
 
 Get started with Document-to-Podcast using one of the options below:
 
-| HuggingFace Spaces  | GitHub Codespaces | Local Installation |
-| ------------------- | ----------------- | ------------------ |
-| [![Try on Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Try%20on-Spaces-blue)](https://huggingface.co/spaces/mozilla-ai/document-to-podcast) | [![Try on Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb) | `pip install document-to-podcast` |
+| Google Colab | HuggingFace Spaces  | GitHub Codespaces |
+| -------------| ------------------- | ----------------- |
+| [![Try on Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mozilla-ai/document-to-podcast/blob/main/demo/notebook.ipynb) | [![Try on Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Try%20on-Spaces-blue)](https://huggingface.co/spaces/mozilla-ai/document-to-podcast) | [![Try on Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb) |
+
+Alternatively, you can install it from pypi:
+
+```bash
+pip install document-to-podcast
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -17,27 +17,48 @@ It is designed to work on most local setups or with [GitHub Codespaces](https://
 
 ## Quick-start
 
-Get started with Document-to-Podcast using one of the options below:
+Get started right away using one of the options below:
 
 | Google Colab | HuggingFace Spaces  | GitHub Codespaces |
 | -------------| ------------------- | ----------------- |
 | [![Try on Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mozilla-ai/document-to-podcast/blob/main/demo/notebook.ipynb) | [![Try on Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Try%20on-Spaces-blue)](https://huggingface.co/spaces/mozilla-ai/document-to-podcast) | [![Try on Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb) |
 
-Alternatively, you can install it from pypi:
+You can also install and use the blueprint locally:
+
+<table>
+<tr>
+<th>CLI</th>
+<th>Demo App</th>
+</tr>
+<tr>
+<td>
 
 ```bash
 pip install document-to-podcast
 ```
 
-## Troubleshooting
+```bash
+document-to-podcast \
+--input_file "example_data/Mozilla-Trustworthy_AI.pdf" \
+--output_folder "example_data"
+--text_to_text_model "Qwen/Qwen2.5-1.5B-Instruct-GGUF/qwen2.5-1.5b-instruct-q8_0.gguf"
+```
 
-> When starting up the codespace, I get the message `Oh no, it looks like you are offline!`
+</td>
+<td>
 
-If you are on Firefox and have Enhanced Tracking Protection `On`, try turning it `Off` for the codespace webpage.
+```bash
+git clone https://github.com/mozilla-ai/document-to-podcast.git
+cd document-to-podcast
+pip install -e .
+```
 
-> During the installation of the package, it fails with `ERROR: Failed building wheel for llama-cpp-python`
-
-You are probably missing the `GNU Make` package. A quick way to solve it is run on your terminal `sudo apt install build-essential`
+```bash
+python -m streamlit run demo/app.py
+```
+</td>
+</tr>
+</table>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,128 +1,27 @@
+<p align="center"><img src="./images/Blueprints-logo.png" width="35%" alt="Project logo"/></p>
+
+# Document-to-podcast: a Blueprint by Mozilla.ai for generating podcasts from documents using local AI
+
 [![](https://dcbadge.limes.pink/api/server/YuMNeuKStr?style=flat)](https://discord.gg/YuMNeuKStr)
 [![Docs](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/docs.yaml/badge.svg)](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/docs.yaml/)
 [![Tests](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/tests.yaml/badge.svg)](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/tests.yaml/)
 [![Ruff](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/lint.yaml/badge.svg?label=Ruff)](https://github.com/mozilla-ai/document-to-podcast/actions/workflows/lint.yaml/)
 
-<p align="center"><img src="./images/Blueprints-logo.png" width="35%" alt="Project logo"/></p>
-
-# Document-to-podcast: a Blueprint by Mozilla.ai for generating podcasts from documents using local AI
-
 This blueprint demonstrate how you can use open-source models & tools to convert input documents into a podcast featuring two speakers.
 It is designed to work on most local setups or with [GitHub Codespaces](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb), meaning no external API calls or GPU access is required. This makes it more accessible and privacy-friendly by keeping everything local.
 
-<p align="center"><a href="https://colab.research.google.com/github/mozilla-ai/document-to-podcast/blob/main/demo/notebook.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" /></a></p>
+<img src="./images/document-to-podcast-diagram.png" width="1200" alt="document-to-podcast Diagram" />
 
 ### 👉 📖 For more detailed guidance on using this project, please visit our [Docs here](https://mozilla-ai.github.io/document-to-podcast/).
-
-### Built with
-- Python 3.10+ (use Python 3.12 for Apple M1/2/3 chips)
-- [Llama-cpp](https://github.com/abetlen/llama-cpp-python) (text-to-text, i.e script generation)
-- [OuteAI](https://github.com/edwko/OuteTTS) (text-to-speech, i.e audio generation)
-- [Streamlit](https://streamlit.io/) (UI demo)
 
 
 ## Quick-start
 
-Get started with Document-to-Podcast using one of the two options below: **GitHub Codespaces** for a hassle-free setup or **Local Installation** for running on your own machine.
+Get started with Document-to-Podcast using one of the options below:
 
----
-
-### **Option 1: GitHub Codespaces**
-
-The fastest way to get started. Click the button below to launch the project directly in GitHub Codespaces:
-
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb)
-
-Once the Codespaces environment launches, inside the terminal, start the Streamlit demo by running:
-   ```bash
-   python -m streamlit run demo/app.py
-   ```
-
-### **Option 2: Local Installation**
-
-1. **Clone the Repository**
-   Inside the Codespaces terminal, run:
-   ```bash
-   git clone https://github.com/mozilla-ai/document-to-podcast.git
-   cd document-to-podcast
-   ```
-
-2. **Install Dependencies**
-   Inside the terminal, run:
-   ```bash
-   pip install -e .
-3. **Run the Demo**
-   Inside the terminal, start the Streamlit demo by running:
-   ```bash
-   python -m streamlit run demo/app.py
-   ```
-
-***NOTE***: The first time you run the demo app it might take a while to generate the script or the audio because it will download the models to the machine which are a few GBs in size.
-
-
-## How it Works
-
-<img src="./images/document-to-podcast-diagram.png" width="1200" />
-
-
-1. **Document Input**
-   Start by either:
-   - Uploading a document in a supported format (e.g., PDF, .txt, or .docx)
-   - Entering a website URL to fetch content directly
-
-2. **Document Pre-Processing**
-   The input is processed to extract and clean the text. This involves:
-   - Extracting readable text from the document or webpage
-   - Removing noise such as URLs, email addresses, and special characters to ensure the text is clean and structured
-
-3. **Script Generation**
-   The cleaned text is passed to a language model to generate a podcast transcript in the form of a conversation between two speakers.
-   - **Model Loading**: The system selects and loads a pre-trained LLM optimized for running locally, using the llama_cpp library. This enables the model to run efficiently on CPUs, making them more accessible and suitable for local setups.
-   - **Customizable Prompt**: A user-defined "system prompt" guides the LLM in shaping the conversation, specifying tone, content, speaker interaction, and format.
-   - **Output Transcript**: The model generates a podcast script in structured format, with each speaker's dialogue clearly labeled.
-     Example output:
-     ```json
-     {
-         "Speaker 1": "Welcome to the podcast on AI advancements.",
-         "Speaker 2": "Thank you! So what's new this week for the latest AI trends?",
-         "Speaker 1": "Where should I start.. Lots has been happening!",
-         ...
-     }
-     ```
-   This step ensures that the podcast script is engaging, relevant, and ready for audio conversion.
-
-4. **Audio Generation**
-  - The generated transcript is converted into audio using a Text-to-Speech (TTS) model.
-  -	Each speaker is assigned a distinct voice.
-	- The final output is saved as an audio file in formats like MP3 or WAV.
-
-## Models
-
-The architecture of this codebase focuses on modularity and adaptability, meaning it shouldn't be too difficult to swap frameworks to use your own suite of models. We have selected fully open source models that are very memory efficient and can run on a laptop CPU with less than 10GB RAM requirements.
-
-### text-to-text
-
-We are using the [llama.cpp](https://github.com/ggerganov/llama.cpp) library, which supports open source models optimized for local inference and minimal hardware requirements. The default text-to-text model in this repo is the open source [Qwen2.5-3B-Instruct](https://huggingface.co/bartowski/Qwen2.5-3B-Instruct-GGUF).
-
-For the complete list of models supported out-of-the-box, visit this [link](https://github.com/ggerganov/llama.cpp?tab=readme-ov-file#text-only).
-
-### text-to-speech
-
-We support models from the [OuteAI](https://github.com/edwko/OuteTTS) package. The default text-to-speech model in this repo is [OuteTTS-0.2-500M](https://huggingface.co/OuteAI/OuteTTS-0.2-500M). Note that the `0.1-350M` version has a `CC-By-4.0` (permissive) license, whereas the newer / better `0.2-500M` version has a `CC-By-NC-4.0` (non-commercial) license.
-For a complete list of models visit [Oute HF](https://huggingface.co/collections/OuteAI) (only the GGUF versions).
-
-In this [repo](https://github.com/Kostis-S-Z/document-to-podcast) you can see examples of using different TTS models with minimal code changes.
-
-## Pre-requisites
-
-- **System requirements**:
-  - OS: Windows, macOS, or Linux
-  - Python 3.10>, <3.12
-  - Minimum RAM: 10 GB
-  - Disk space: 32 GB minimum
-
-- **Dependencies**:
-  - Dependencies listed in `pyproject.toml`
+| HuggingFace Spaces  | GitHub Codespaces | Local Installation |
+| ------------------- | ----------------- | ------------------ |
+| [![Try on Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Try%20on-Spaces-blue)](https://huggingface.co/spaces/mozilla-ai/document-to-podcast) | [![Try on Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=888426876&skip_quickstart=true&machine=standardLinux32gb) | `pip install document-to-podcast` |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This makes it more accessible and privacy-friendly by keeping everything local.
 <img src="./images/document-to-podcast-diagram.png" width="1200" alt="document-to-podcast Diagram" />
 
 ### 👉 📖 For more detailed guidance on using this project, please visit our [Docs](https://mozilla-ai.github.io/document-to-podcast/).
+### 👉 🔨 Built with
+- Python 3.10+ (use Python 3.12 for Apple M1/2/3 chips)
+- [Llama-cpp](https://github.com/abetlen/llama-cpp-python)
+- [Streamlit](https://streamlit.io/) (UI demo)
 
 ### 👉 🧠 Check the [Supported Models](https://mozilla-ai.github.io/document-to-podcast/customization/#supported-models).
 
@@ -27,7 +31,7 @@ Get started right away using one of the options below:
 
 You can also install and use the blueprint locally:
 
-### CLI
+### Command Line Interface
 
 ```bash
 pip install document-to-podcast
@@ -40,7 +44,7 @@ document-to-podcast \
 --text_to_text_model "Qwen/Qwen2.5-1.5B-Instruct-GGUF/qwen2.5-1.5b-instruct-q8_0.gguf"
 ```
 
-### Demo App
+### Graphical Interface App
 
 ```bash
 git clone https://github.com/mozilla-ai/document-to-podcast.git

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,10 @@
 
 ::: document_to_podcast.inference.model_loaders
 
+::: document_to_podcast.inference.model_loaders.TTS_LOADERS
+
 ::: document_to_podcast.inference.text_to_text
 
 ::: document_to_podcast.inference.text_to_speech
+
+::: document_to_podcast.inference.text_to_speech.TTS_INFERENCE

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -3,15 +3,35 @@
 The Document-to-Podcast Blueprint is designed to be flexible and adaptable to your specific needs.
 This guide outlines the key parameters you can customize and explains how to make these changes depending on whether you’re running the application via app.py or the CLI pipeline.
 
-## 🖋️ **Key Parameters for Customization**
+## 🧠 **Supported models**
+
+There are 2 different parameters to customize the models being used:
+
+### **`text_to_text_model`**
+
+The language model used to generate the podcast script.
+
+Any model that can be loaded by [`LLama.from_pretrained`](https://llama-cpp-python.readthedocs.io/en/latest/#pulling-models-from-hugging-face-hub) can be used here.
+
+Format is expected to be `{org}/{repo}/{filename}`.
+For example: `Qwen/Qwen2.5-1.5B-Instruct-GGUF/qwen2.5-1.5b-instruct-q8_0.gguf`.
+
+
+### **`text_to_speech_model`**
+
+The model used to generate the audio from the podcast script.
+
+You can use any of the models listed in [`TTS_LOADERS`](api.md/#document_to_podcast.inference.model_loaders.TTS_LOADERS) out of the box.
+We currently support [OuteTTS](https://github.com/edwko/OuteTTS).
+
+If you want to use a different model, you can integrate it by implementing the `_load` and `_text_to_speech` functions and registering them in [`TTS_LOADERS`](api.md/#document_to_podcast.inference.model_loaders.TTS_LOADERS) and [`TTS_INFERENCE`](api.md/#document_to_podcast.inference.model_loaders.TTS_INFERENCE).
+You can check [this repo](https://github.com/Kostis-S-Z/document-to-podcast/) where different text-to-speech models are integrated.
+
+## 🖋️ **Other Customizable Parameters**
 
 - **`input_file`**: The input file specifies the document to be processed. Supports the following formats: `pdf`, `html`, `txt`, `docx`, `md`.
 
-- **`text_to_text_model`**: The language model used to generate the podcast script. Note: The model parameter must be in GGFUF format, for example: `Qwen/Qwen2.5-1.5B-Instruct-GGUF/qwen2.5-1.5b-instruct-q8_0.gguf`.
-
 - **`text_to_text_prompt`**: Defines the tone, structure, and instructions for generating the podcast script. This prompt is crucial for tailoring the conversation style to your project.
-
-- **`text_to_speech_model`**: Specifies the model used for text-to-speech conversion. You can change this to achieve the desired voice style or improve performance. Check `config.py` to choose from supported models.
 
 - **`speakers`**: Defines the podcast participants, including their names, roles, descriptions, and voice profiles. Customize this to create engaging personas and voices for your podcast.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,3 +55,14 @@ Get started with Document-to-Podcast using one of the options below:
          ```bash
          python -m streamlit run demo/app.py
          ```
+
+
+## Troubleshooting
+
+> When starting up the codespace, I get the message `Oh no, it looks like you are offline!`
+
+If you are on Firefox and have Enhanced Tracking Protection `On`, try turning it `Off` for the codespace webpage.
+
+> During the installation of the package, it fails with `ERROR: Failed building wheel for llama-cpp-python`
+
+You are probably missing the `GNU Make` package. A quick way to solve it is run on your terminal `sudo apt install build-essential`


### PR DESCRIPTION
No strong opinion.

I prefer the README to contain as minimum information as possible and instead serve to redirect people to different places like the Docs, Colab, HF Space.

My main concern is that there is no clear line on what details should be duplicated in the README.
Even when that is clear, it is prone to become outdated as someone needs to remember updating the same thing multiple times (i.e. when we changed the default model used)