### PR TITLE
Wrap download logic in streamlit fragments

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -41,6 +41,34 @@ def numpy_to_wav(audio_array: np.ndarray, sample_rate: int) -> io.BytesIO:
     return wav_io
 
 
+@st.fragment
+def download_audio(audio_wav: io.BytesIO):
+    """
+    Display button to download audio file of the podcast. Wrap in fragment so
+    the app is not refreshed when clicked.
+    """
+    if st.download_button(
+        label="Save Podcast to audio file",
+        data=audio_wav,
+        file_name="podcast.wav",
+    ):
+        st.markdown("Podcast saved to disk!")
+
+
+@st.fragment
+def download_script():
+    """
+    Display button to download the text script of the podcast. Wrap in fragment
+    so the app is not refreshed when clicked.
+    """
+    if st.download_button(
+        label="Save Podcast script to text file",
+        data=st.session_state.script,
+        file_name="script.txt",
+    ):
+        st.markdown("Script saved to disk!")
+
+
 script = "script"
 audio = "audio"
 gen_button = "generate podcast button"
@@ -205,16 +233,6 @@ if "clean_text" in st.session_state:
             st.session_state.audio, sample_rate, silence_pad=0.0
         )
         audio_wav = numpy_to_wav(audio_np, sample_rate)
-        if st.download_button(
-            label="Save Podcast to audio file",
-            data=audio_wav,
-            file_name="podcast.wav",
-        ):
-            st.markdown("Podcast saved to disk!")
 
-        if st.download_button(
-            label="Save Podcast script to text file",
-            data=st.session_state.script,
-            file_name="script.txt",
-        ):
-            st.markdown("Script saved to disk!")
+        download_audio(audio_wav)
+        download_script()


### PR DESCRIPTION
# What's changing

Wrap the download buttons for the podcast script and audio files into streamlit fragments. This way we avoid refreshing the application when clicking those buttons. This also addresses comment https://github.com/mozilla-ai/document-to-podcast/pull/42#pullrequestreview-2488384228, about losing the text and audio snippets in the UI (because they are not persisted), since we no longer refresh the app.

Closes #71 

# How to test it

Steps to test the changes:

1. Run the demo to generate a podcast.
2. Click on the "Save Podcast to audio file".
3. Verify the page won't refresh. In addition, verify the text and audio snippets of the podcast won't disappear.
4. Do the same for the "Save Podcast script to text file".

# Additional notes for reviewers

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and under `/docs`)
