### PR TITLE
Clear session state when inputs change

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -52,7 +52,15 @@ if gen_button not in st.session_state:
     st.session_state[gen_button] = False
 
 
+def clear_podcast_state():
+    st.session_state["clean_text"] = None
+    st.session_state[gen_button] = False
+    st.session_state.script = ""
+    st.session_state.audio = []
+
+
 def gen_button_clicked():
+    clear_podcast_state()
     st.session_state[gen_button] = True
 
 
@@ -64,11 +72,15 @@ st.markdown("Built with: ‚≠ê https://github.com/mozilla-ai/document-to-podcast ‚
 st.header("Upload a File")
 
 uploaded_file = st.file_uploader(
-    "Choose a file", type=["pdf", "html", "txt", "docx", "md"]
+    "Choose a file",
+    type=["pdf", "html", "txt", "docx", "md"],
+    on_change=clear_podcast_state,
 )
 
 st.header("Or Enter a Website URL")
-url = st.text_input("URL", placeholder="https://blog.mozilla.ai/...")
+url = st.text_input(
+    "URL", placeholder="https://blog.mozilla.ai/...", on_change=clear_podcast_state
+)
 
 if uploaded_file is not None or url:
     st.divider()
@@ -92,6 +104,7 @@ if uploaded_file is not None or url:
         st.text_area(
             f"Number of characters before cleaning: {len(raw_text)}",
             f"{raw_text[:500]} . . .",
+            on_change=clear_podcast_state,
         )
 
     clean_text = DATA_CLEANERS[extension](raw_text)
@@ -100,12 +113,13 @@ if uploaded_file is not None or url:
         st.text_area(
             f"Number of characters after cleaning: {len(clean_text)}",
             f"{clean_text[:500]} . . .",
+            on_change=clear_podcast_state,
         )
     st.session_state["clean_text"] = clean_text
 
 st.divider()
 
-if "clean_text" in st.session_state:
+if "clean_text" in st.session_state and st.session_state["clean_text"]:
     clean_text = st.session_state["clean_text"]
 
     st.divider()
@@ -149,7 +163,9 @@ if "clean_text" in st.session_state:
     st.subheader("Speaker configuration")
     for s in SPEAKERS:
         s.pop("id", None)
-    speakers = st.data_editor(SPEAKERS, num_rows="dynamic")
+    speakers = st.data_editor(
+        SPEAKERS, num_rows="dynamic", on_change=clear_podcast_state
+    )
 
     if st.button("Generate Podcast", on_click=gen_button_clicked):
         for n, speaker in enumerate(speakers):


### PR DESCRIPTION
# What's changing

Clear the persisted session state when the inputs of the podcast generation are changed or the "Generate Podcast" button is clicked. This fixes #137, where previously generated podcasts were concatenated into the script and audio file. Also when the inputs change (e.g., the chosen file for the podcast), it makes sense to reset the state and recalculate it as part of the page refresh.

Closes #137

# How to test it

Steps to test the changes for #137:

1. Generate a podcast (upload a file and click "Generate Podcast").
2. Click "Generate Podcast" again to generate the podcast a second time.
3. Download the podcast script text and audio files.
4. Verify only the last podcast is in the downloaded files. The downloaded content should match the dialog snippets in the UI.

---

Other tests regarding clearing state:

1. Upload a file.
2. Remove the uploaded file by clicking the "x" button.
3. Ensure all the sections below are removed (e.g., "Loading and Cleaning Data", "Podcast generation", etc..)
>
1. Upload a file.
2. Generate a podcast.
3. Change one of the inputs (speaker configuration, raw/cleaned text, upload a different file, enter a URL, etc...)
5. Ensure the generated podcast section is reset, the download buttons are removed.

# Additional notes for reviewers

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [ ] Updated the documentation (both comments in code and under `/docs`)
